### PR TITLE
[Watch] Fix Error reporting

### DIFF
--- a/lib/theme/watch.js
+++ b/lib/theme/watch.js
@@ -100,7 +100,7 @@ module.exports = function *(argv) {
         log(`Deleted ${filePath}`, 'green')
       }
     }).catch((err) => {
-      log(err.stack, 'red')
+      log(err, 'red')
     })
   })
 

--- a/lib/theme/watch.js
+++ b/lib/theme/watch.js
@@ -100,6 +100,9 @@ module.exports = function *(argv) {
         log(`Deleted ${filePath}`, 'green')
       }
     }).catch((err) => {
+      if (err.stack) {
+        err = err.stack
+      }
       log(err, 'red')
     })
   })


### PR DESCRIPTION
I believe that since the err originates from Shopify API, there is no stack, so `err.stack` results in `undefined` log call. This fix results in error reporting like this instead...

```
{"asset":["Liquid syntax error (line 49): Unknown tag 'endunless'"]}
{"key":"snippets/account-form-login.liquid"}
```