### PR TITLE
Adds an update param

### DIFF
--- a/src/commands/theme/watch.js
+++ b/src/commands/theme/watch.js
@@ -17,6 +17,8 @@ module.exports = async function (argv) {
   const config = await loadConfig()
   const target = await getTarget(config, argv)
 
+  const { update } = argv
+
   const lock = new AwaitLock()
 
   try {
@@ -69,6 +71,16 @@ module.exports = async function (argv) {
         })
 
         log(`Added/Updated ${filePath}`, `green`)
+
+        /**
+         * If update is defined, update a file with a random string to help 
+         * tools like browser-sync watch for changes
+         */
+        if (update) {
+          const randomString = Math.random().toString(36).substring(2, 15)
+          fs.writeFileSync(update, randomString, `utf8`)
+          log(`${update} updated`, `green`)
+        }
       } else if (event === `unlink`) {
         await requestify(target, {
           method: `delete`,


### PR DESCRIPTION
I really enjoy the tool, but I found it a little bit challenging to work with tools like browser sync.

I have added in an option to allow you to pass in an `--update` param to your script that will update a passed in file with a random string once the watch has finished uploading. It seems to be much more reliable then the solutions presented in the `slate` repo.

example:

```
scripts: {
  ...,
  "watch": "qs theme watch --target YourTarget --update './src/update.txt'",
  "browserSync": "browser-sync start --proxy 'https://mystoreurl.myshopify.com/' --files './src/update.txt' --config bs-config.js",
}
```

or:


```
scripts: {
  ...,
  "watch": "qs theme watch --target YourTarget --update './src/update.txt'",
}
```

```
const path = require("path");
const browserSync = require("browser-sync").create();

browserSync.init({
  files: `${path.join(__dirname, "./src/update.txt")}`,
  proxy: 'https://mystoreurl.myshopify.com/',
  port: 8000,
  snippetOptions: {
    rule: {
      match: /<head[^>]*>/i,
      fn(snippet, match) {
        return match + snippet;
      },
    },
  },
});
```